### PR TITLE
change: narrow down the types of dictionary values to string

### DIFF
--- a/schema.jsd
+++ b/schema.jsd
@@ -5,6 +5,7 @@
     "type": "object",
     "required": ["name", "description", "url", "mapping", "samples"],
     "additionalProperties": false,
+    "description": "Transliteration Schema",
     "properties": {
         "name": {
             "description": "Schema name",

--- a/schema.jsd
+++ b/schema.jsd
@@ -4,6 +4,7 @@
     "title": "Transliteration Schema",
     "type": "object",
     "required": ["name", "description", "url", "mapping", "samples"],
+    "additionalProperties": false,
     "properties": {
         "name": {
             "description": "Schema name",
@@ -34,19 +35,23 @@
         },
         "mapping": {
             "description": "Mapping for individual letters",
-            "type": "object"
+            "type": "object",
+            "additionalProperties": { "type": "string" }
         },
         "prev_mapping": {
             "description": "Mapping for letters with respect to previous sibling",
-            "type": ["object", "null"]
+            "type": ["object", "null"],
+            "additionalProperties": { "type": "string" }
         },
         "next_mapping": {
             "description": "Mapping for letters with respect to next sibling",
-            "type": ["object", "null"]
+            "type": ["object", "null"],
+            "additionalProperties": { "type": "string" }
         },
         "ending_mapping": {
             "description": "Mapping for word endings",
-            "type": ["object", "null"]
+            "type": ["object", "null"],
+            "additionalProperties": { "type": "string" }
         },
         "samples": {
             "description": "Transliteraton samples",


### PR DESCRIPTION
In https://github.com/nalgeon/iuliia-js `schema.jsd` is currently used for schemas validation.
I am planning to use this JSON schema as a source of TypeScript definition of `TransliterationSchema` interface.

Currently this is equivalent to the following type:

```ts
export interface TransliterationSchema {
  /**
   * Schema name
   */
  name: string;
  /**
   * Schema name aliases
   */
  aliases?: string[];
  /**
   * Schema description
   */
  description: string;
  /**
   * Schema description url
   */
  url: string;
  /**
   * Schema comments
   */
  comments?: string[];
  /**
   * Mapping for individual letters
   */
  mapping: {
    [k: string]: unknown; // FIXME
  };
  /**
   * Mapping for letters with respect to previous sibling
   */
  prev_mapping?: {
    [k: string]: unknown; // FIXME
  } | null;
  /**
   * Mapping for letters with respect to next sibling
   */
  next_mapping?: {
    [k: string]: unknown; // FIXME
  } | null;
  /**
   * Mapping for word endings
   */
  ending_mapping?: {
    [k: string]: unknown; // FIXME
  } | null;
  /**
   * Transliteraton samples
   */
  samples: string[][];
  [k: string]: unknown; // FIXME
}
```

The JSONSchema-to-TypeScript translation is correct, but the schema can be slightly improved to produce `{ [k: string]: string }` dictionaries instead of `{ [k: string]: unknown }`. It will improve validation as well.