### PR TITLE
Add uzbek translit scheme

### DIFF
--- a/uz_1.json
+++ b/uz_1.json
@@ -1,0 +1,52 @@
+{
+    "name": "uz_1",
+    "description": "Uzbekistan cyr-lat transliteration schema",
+    "url": "https://en.wikipedia.org/wiki/Uzbek_alphabet",
+    "mapping": {
+        "а":	"a",
+        "б":	"b",
+        "в":	"v",
+        "г":	"g",
+        "д":	"d",
+        "е":	"e",
+        "ё":	"yo",
+        "ж":	"j",
+        "з":	"z",
+        "и":	"i",
+        "й":	"y",
+        "к":	"k",
+        "л":	"l",
+        "м":	"m",
+        "н":	"n",
+        "о":	"o",
+        "п":	"p",
+        "р":	"r",
+        "с":	"s",
+        "т":	"t",
+        "у":	"u",
+        "ф":	"f",
+        "х":	"x",
+        "ц":	"s",
+        "ч":	"ch",
+        "ш":	"sh",
+        "щ":	"sh",
+        "ъ":	"ʼ",
+        "ы":	"i",
+        "э":	"e",
+        "ю":	"yu",
+        "я":	"ya",
+        "ў":	"oʻ",
+        "ғ":	"gʻ",
+        "қ":	"q",
+        "ҳ":	"h"
+    },
+    "prev_mapping": null,
+    "next_mapping": null,
+    "ending_mapping": null,
+    "samples": [
+        [
+            "Юлия, Ёшкар-Оладан олинган бу юмшоқ франтсуз рулоларини кўпроқ истеъмол қилинг ва Олтой чойини ичинг",
+            "Yuliya, Yoshkar-Oladan olingan bu yumshoq frantsuz rulolarini koʻproq isteʼmol qiling va Oltoy choyini iching"
+        ]
+    ]
+}


### PR DESCRIPTION
New scheme added.

This scheme corresponds to Uzbekistan’s official transliteration system.

https://en.wikipedia.org/wiki/Uzbek_alphabet